### PR TITLE
Fix typo in RegistryStepDefinition host address

### DIFF
--- a/tests/acceptation/src/test/java/scenarios/RegistryStepDefinition.java
+++ b/tests/acceptation/src/test/java/scenarios/RegistryStepDefinition.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.*;
 public class RegistryStepDefinition {
 
 
-    private String host = "host";
+    private String host = "localhost";
     private int port = 8080;
 
     private JSONObject citizen;


### PR DESCRIPTION
Fix a small typo in acceptation test source file `RegistryStepDefinition.java` located in `5A-Microservices-Integration/tests/acceptation/src/test/java/scenarios/`.

Variable host value was `host` but should be `localhost`