### PR TITLE
Fix typo in stress test readme

### DIFF
--- a/tests/stress/readme.md
+++ b/tests/stress/readme.md
@@ -16,7 +16,7 @@ We also configure the maven build phase to trigger the Scala compiler, and the G
 
 ## Writing a Stress test
 
-A stress test is a plan Scala program, modelling how the service must be stressed. We start by defining an `httpConf` variable that configures the target. Here, we are targeting the `Registry` service, sending and receiving `son` data.
+A stress test is a plan Scala program, modelling how the service must be stressed. We start by defining an `httpConf` variable that configures the target. Here, we are targeting the `Registry` service, sending and receiving `json` data.
 
 
 ```scala


### PR DESCRIPTION
Fix a small typo inside the stress test readme file.